### PR TITLE
Set default ios jpg compression to 0.9

### DIFF
--- a/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
+++ b/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
@@ -539,7 +539,7 @@
 - (NSData*)getImageData:(UIImage*)img type:(NSString*) type {
     NSData *data;
     if ([type isEqualToString: @"jpg"]) {
-        data = UIImageJPEGRepresentation(img, 1.0);
+        data = UIImageJPEGRepresentation(img, 0.9);
     } else {
         data = UIImagePNGRepresentation(img);
     }


### PR DESCRIPTION
To align on android compression parameter used in the project, set default iOs compression to 0.9.
This also allows for better file size with almost no compression loss.