### PR TITLE
Add ability to load default paths on ImageEditor construction

### DIFF
--- a/src/ImageEditor.js
+++ b/src/ImageEditor.js
@@ -95,7 +95,9 @@ class ImageEditor extends React.Component {
         localSourceImage: null,
 
         permissionDialogTitle: "",
-        permissionDialogMessage: ""
+        permissionDialogMessage: "",
+
+        defaultPaths: [],
     };
 
     state = {
@@ -104,7 +106,7 @@ class ImageEditor extends React.Component {
 
     constructor(props) {
         super(props);
-        this._pathsToProcess = [];
+        this._pathsToProcess = this.props.defaultPaths || [];
         this._paths = [];
         this._path = null;
         this._handle = null;


### PR DESCRIPTION
This allows to restore an array of Paths when instanciating a new ImageEditor